### PR TITLE
Tracking Draft for File stream based operations on the version list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,6 @@ test/fixtures/fake_home_path/.local/share/gem/specs
 *.gem
 test/fixtures/*.fixture
 data/*
+**/tmp
 
 /coverage

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ end
 group :test do
   gem 'minitest'
   gem 'minitest-reporters'
+  gem 'minitest-stub-const'
   gem 'rack-test'
   gem 'rake'
 

--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,6 @@
 $:.unshift(File.expand_path(File.join(File.dirname(__FILE__), "lib")))
 require "geminabox"
 
+Geminabox.rubygems_proxy = true
+
 run Geminabox::Server

--- a/lib/geminabox/compact_index_api.rb
+++ b/lib/geminabox/compact_index_api.rb
@@ -11,14 +11,12 @@ module Geminabox
     end
 
     def names
-      local_gem_list = Set.new(all_gems.list)
-      return format_gem_names(local_gem_list) unless Geminabox.rubygems_proxy
-
-      remote_name_data = remote_names
-      return format_gem_names(local_gem_list) unless remote_name_data
-
-      remote_gem_list = remote_name_data.split("\n")[1..-1]
-      format_gem_names(local_gem_list.merge(remote_gem_list))
+      gem_list = Set.new(all_gems.list)
+      if Geminabox.rubygems_proxy
+        remote_gem_list = remote_names&.split("\n")[1..-1]
+        gem_list = gem_list.merge(remote_gem_list) if remote_gem_list
+      end
+      format_gem_names(gem_list)
     end
 
     def local_names

--- a/lib/geminabox/compact_indexer.rb
+++ b/lib/geminabox/compact_indexer.rb
@@ -70,6 +70,7 @@ module Geminabox
         File.binread(path)
       else
         reindex
+        File.binread(path)
       end
     end
 

--- a/lib/geminabox/compact_indexer.rb
+++ b/lib/geminabox/compact_indexer.rb
@@ -5,7 +5,7 @@ module Geminabox
 
     module PathMethods
       def index_path
-        File.expand_path(File.join(datadir, 'compact_index'))
+        File.expand_path(File.join(Geminabox.data, 'compact_index'))
       end
 
       def versions_path
@@ -14,6 +14,10 @@ module Geminabox
 
       def merged_versions_path
         File.join(index_path, 'merged_versions')
+      end
+
+      def proxy_versions_path
+        File.join(Geminabox.data, 'remote_cache', 'versions')
       end
 
       def info_path

--- a/lib/geminabox/compact_indexer.rb
+++ b/lib/geminabox/compact_indexer.rb
@@ -66,7 +66,11 @@ module Geminabox
 
     def fetch_versions
       path = versions_path
-      File.binread(path) if File.exist?(path)
+      if File.exist?(path)
+        File.binread(path)
+      else
+        reindex
+      end
     end
 
     def reindex(specs = nil)

--- a/lib/geminabox/gem_versions_merge.rb
+++ b/lib/geminabox/gem_versions_merge.rb
@@ -29,7 +29,7 @@ module Geminabox
             end
           end
 
-          write_version_entries(preamble, local_io, remote_versions_file)
+          write_version_entries(local_io, remote_versions_file)
           File.read(merged_versions_path)
         end
       end

--- a/lib/geminabox/gem_versions_merge.rb
+++ b/lib/geminabox/gem_versions_merge.rb
@@ -19,6 +19,7 @@ module Geminabox
           preamble = (local_time > remote_time ? local_preamble : remote_preamble)
           try_load_cached_file do |merged_versions_file|
             unless merged_versions_file.eof?
+              merged_versions_file.flock(File::LOCK_EX)
               merged_versions_preamble = merged_versions_file.readline
               merged_version_time = Time.parse(merged_versions_preamble.split[1])
               preamble_time = Time.parse(preamble.split[1])

--- a/lib/geminabox/gem_versions_merge.rb
+++ b/lib/geminabox/gem_versions_merge.rb
@@ -38,14 +38,14 @@ module Geminabox
 
     def self.write_version_entries(local_gem_io, remote_version_io)
       try_load_cached_file('w') do |merged_versions_file|
-        local_gem_list = local_gem_io.readlines.map { |it| it.split[0] }
+        local_gem_list = local_gem_io.readlines[1..-1].map { |it| it.split[0] }
         local_gem_io.rewind
         local_gem_io.readline # advance past preamble since we're writing our own merged versions file
-        preamble = "created at: #{Time.now}"
+        preamble = "created_at: #{Time.now}"
         merged_versions_file.flock(File::LOCK_EX)
-        merged_versions_file.write("#{preamble}")
+        merged_versions_file.write("#{preamble}\n")
         merged_versions_file.write(local_gem_io.readline) # get the ---
-        current_local_gem = local_gem_io.readline
+        current_local_gem = local_gem_list.any? ? local_gem_io.readline : nil
         remote_version_io.each_line do |remote_version_line|
           next if remote_version_line.eql?("---\n")
           remote_gem_name = remote_version_line.split[0]

--- a/lib/geminabox/gem_versions_merge.rb
+++ b/lib/geminabox/gem_versions_merge.rb
@@ -3,39 +3,97 @@ require 'time'
 module Geminabox
   module GemVersionsMerge
     extend CompactIndexer::PathMethods
+
     def self.datadir
       Geminabox.data
     end
 
-    def self.merge(local_gem_list, remote_gem_list)
-      return local_gem_list unless remote_gem_list
-      merged_versions = try_load_cached_file
+    def self.merge(local_gem_list)
+      return local_gem_list unless File.exist?(proxy_versions_path)
+      File.open(proxy_versions_path) do |remote_versions_file|
+        StringIO.open(local_gem_list) do |local_io|
+          remote_preamble = remote_versions_file.readline
+          local_preamble = local_io.readline
+          remote_time = Time.parse(remote_preamble.split[1])
+          local_time = Time.parse(local_preamble.split[1])
+          preamble = (local_time > remote_time ? local_preamble : remote_preamble)
+          try_load_cached_file do |merged_versions_file|
+            unless merged_versions_file.eof?
+              merged_versions_preamble = merged_versions_file.readline
+              merged_version_time = Time.parse(merged_versions_preamble.split[1])
+              preamble_time = Time.parse(preamble.split[1])
+              if merged_version_time >= preamble_time
+                merged_versions_file.rewind
+                merged_versions_file.read
+              end
+            end
+          end
 
-      local_split = local_gem_list.split("\n")
-      remote_split = remote_gem_list.split("\n")
-      merged_versions_split = merged_versions.split("\n")
-
-      local_time = Time.parse(local_split[0].split[1])
-      remote_time = Time.parse(remote_split[0].split[1])
-      preamble = (local_time > remote_time ? local_split : remote_split)[0..1]
-      unless merged_versions.empty?
-        merged_version_time = Time.parse(merged_versions_split[0].split[1])
-        preamble_time = Time.parse(preamble[0].split[1])
-        return merged_versions if merged_version_time >= preamble_time
+          write_version_entries(preamble, local_io, remote_versions_file)
+          File.read(merged_versions_path)
+        end
       end
 
-      combined = gems_hash(remote_split).merge(gems_hash(local_split))
-      result = "#{(preamble + combined.values.sort).join("\n")}\n"
-      write_merged_versions(result)
-      result
     end
 
-    def self.write_merged_versions(file_content)
-      File.write(merged_versions_path, file_content)
+    def self.write_version_entries(local_gem_io, remote_version_io)
+      try_load_cached_file('w') do |merged_versions_file|
+        local_gem_list = local_gem_io.readlines.map { |it| it.split[0] }
+        local_gem_io.rewind
+        local_gem_io.readline # advance past preamble since we're writing our own merged versions file
+        preamble = "created at: #{Time.now}"
+        merged_versions_file.flock(File::LOCK_EX)
+        merged_versions_file.write("#{preamble}")
+        merged_versions_file.write(local_gem_io.readline) # get the ---
+        current_local_gem = local_gem_io.readline
+        remote_version_io.each_line do |remote_version_line|
+          next if remote_version_line.eql?("---\n")
+          remote_gem_name = remote_version_line.split[0]
+          wrote_local_gem = if local_gem_list.include?(remote_gem_name)
+                              if current_local_gem
+                                merged_versions_file.write(current_local_gem)
+                                true
+                              else
+                                # no-op, see: https://github.com/rubygems/rubygems.org/issues/3904
+                              end
+                            elsif current_local_gem && remote_version_line > current_local_gem
+                              merged_versions_file.write(current_local_gem)
+                              while current_local_gem&.< remote_version_line
+                                current_local_gem = advance_local_gem(local_gem_io)
+                                merged_versions_file.write(current_local_gem) if current_local_gem&.< remote_version_line
+                              end
+                              merged_versions_file.write(remote_version_line)
+                              false
+                            else
+                              # if current local gem > remote gem
+                              merged_versions_file.write(remote_version_line)
+                              false
+                            end
+          current_local_gem = advance_local_gem(local_gem_io) if wrote_local_gem
+        end
+        if current_local_gem
+          merged_versions_file.write(current_local_gem)
+          merged_versions_file.write(local_gem_io.readlines) unless local_gem_io.eof?
+        end
+        merged_versions_file.flock(File::LOCK_UN)
+      end
     end
 
-    def self.try_load_cached_file
-      File.exist?(merged_versions_path) && File.read(merged_versions_path) || ""
+    def self.advance_local_gem(local_gem_io)
+      if !local_gem_io.eof?
+        local_gem_io.readline
+      else
+        nil
+      end
+    end
+
+    def self.try_load_cached_file(mode = "r")
+      block = ->(io) { yield(io); io.close }
+      if mode.eql?('w') || File.exist?(merged_versions_path)
+        File.open(merged_versions_path, mode, &block)
+      else
+        StringIO.open("", mode, &block)
+      end
     end
 
     def self.gems_hash(source)

--- a/lib/geminabox/rubygems_compact_index_api.rb
+++ b/lib/geminabox/rubygems_compact_index_api.rb
@@ -1,7 +1,9 @@
 require 'uri'
+require 'open-uri'
 
 module Geminabox
   class RubygemsCompactIndexApi
+    include CompactIndexer::PathMethods
 
     def fetch_info(gem_name, etag = nil)
       fetch("/info/#{gem_name}", etag)
@@ -9,6 +11,10 @@ module Geminabox
 
     def fetch_versions(etag = nil)
       fetch('/versions', etag)
+    end
+
+    def download_versions(etag, cache)
+      download('/versions', etag, cache)
     end
 
     def fetch_names(etag = nil)
@@ -24,6 +30,23 @@ module Geminabox
     rescue StandardError
       return [0, nil] if Geminabox.allow_remote_failure
 
+      raise
+    end
+
+    def download(path, etag, cache)
+      headers = {}
+      headers['If-None-Match'] = %("#{etag}") if etag
+      proxy_versions_path = "#{cache.cache_path}#{path}"
+      case io = OpenURI::open_uri(rubygems_uri(path), **(headers))
+      when StringIO then File.open(proxy_versions_path, 'w') { |f| f.write(io.read) }
+      when Tempfile then io.close; FileUtils.cp(io.path, proxy_versions_path)
+      end
+      [200, "#{cache.cache_path}#{path} updated."]
+    rescue OpenURI::HTTPError => e
+      return [304, nil] if e.message.include?('304')
+      raise
+    rescue StandardError
+      return [0, nil] if Geminabox.allow_remote_failure
       raise
     end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -43,8 +43,7 @@ unless ENV['RM_INFO']
 end
 
 require 'webmock/minitest'
-# WebMock.disable_net_connect!(:allow_localhost => true)
-WebMock.allow_net_connect!
+WebMock.disable_net_connect!(:allow_localhost => true)
 
 Capybara.default_driver = :mechanize
 Capybara.app_host = "http://localhost"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -34,14 +34,17 @@ require 'capybara/mechanize'
 require 'capybara/dsl'
 
 require 'minitest/reporters'
-if ENV['MINITEST_REPORTER']
-  Minitest::Reporters.use!
-else
-  Minitest::Reporters.use!([Minitest::Reporters::DefaultReporter.new])
+unless ENV['RM_INFO']
+  if ENV['MINITEST_REPORTER']
+    Minitest::Reporters.use!
+  else
+    Minitest::Reporters.use!([Minitest::Reporters::DefaultReporter.new])
+  end
 end
 
 require 'webmock/minitest'
-WebMock.disable_net_connect!(:allow_localhost => true)
+# WebMock.disable_net_connect!(:allow_localhost => true)
+WebMock.allow_net_connect!
 
 Capybara.default_driver = :mechanize
 Capybara.app_host = "http://localhost"

--- a/test/test_support/geminabox_test_case.rb
+++ b/test/test_support/geminabox_test_case.rb
@@ -217,7 +217,7 @@ class Geminabox::TestCase < Minitest::Test
   end
 
   def log_to_stdout?
-    Minitest::Reporters.reporters.any?{|reporter| reporter.instance_of?(Minitest::Reporters::SpecReporter)}
+    Minitest::Reporters.reporters&.any?{|reporter| reporter.instance_of?(Minitest::Reporters::SpecReporter)} || ENV['RM_INFO']
   end
 
   def start_app!
@@ -271,6 +271,7 @@ class Geminabox::TestCase < Minitest::Test
 
   def stop_app!
     Process.kill(1, @app_server) if @app_server
+    @app_server.kill if @app_server.is_a? Thread
   end
 
   def gem_file(*args)

--- a/test/units/geminabox/compact_index_api_test.rb
+++ b/test/units/geminabox/compact_index_api_test.rb
@@ -55,7 +55,7 @@ module Geminabox
       inject_gems do |builder|
         builder.gem "x"
       end
-      refute CompactIndexApi.new.local_versions
+      assert CompactIndexApi.new.local_versions
     end
 
     def test_local_for_standalone_server

--- a/test/units/geminabox/gem_versions_merge_test.rb
+++ b/test/units/geminabox/gem_versions_merge_test.rb
@@ -5,23 +5,26 @@ module Geminabox
 
     def test_merge_local_over_remote
       local = "created_at: 2021-07-27T16:14:36.466+0000\n---\ntest-gem 0.0.1 91643f56b430feed3f6725c91fcfac70\n"
-      remote = "created_at: 2021-06-27T16:14:36.466+0000\n---\ntest-gem 0.0.5 e7218e76477e2137355d2e7ded094925\n"
+      remote = "created_at: 2021-07-27T16:14:36.466+0000\n---\ntest-gem 0.0.5 e7218e76477e2137355d2e7ded094925\n"
+      File.write(GemVersionsMerge.proxy_versions_path, remote)
       expected = local
-      assert_equal expected, GemVersionsMerge.merge(local, remote)
+      assert_equal expected, GemVersionsMerge.merge(local)
     end
 
     def test_timestamp_local_over_remote
       local = "created_at: 2021-06-27T16:14:36.466+0000\n---\ntest-gem 0.0.1 91643f56b430feed3f6725c91fcfac70\n"
       remote = "created_at: 2020-06-27T16:14:36.466+0000\n---\ntest-gem 0.0.5 e7218e76477e2137355d2e7ded094925\n"
+      File.write(GemVersionsMerge.proxy_versions_path, remote)
       expected = local[/created_at:\s(\S+)\s/]
-      timestamp = GemVersionsMerge.merge(local, remote)[/created_at:\s(\S+)\s/]
+      timestamp = GemVersionsMerge.merge(local)[/created_at:\s(\S+)\s/]
       assert_equal expected, timestamp
     end
 
     def test_merge_multiple_local_over_remote
       local = "created_at: 2021-06-27T16:14:36.466+0000\n---\ntest-gem1 0.0.1 91643f56b430feed3f6725c91fcfac70\ntest-gem2 0.0.1 75f21fffe3703239725b848bf82d3143\n"
       remote = "created_at: 2021-06-27T16:14:36.466+0000\n---\ntest-gem2 0.0.2 c379eb80dd9b53e8b99e5507c8aebcb0\ntest-gem3 0.0.1 4e58bc03e301f704950410b713c20b69\ntest-gem4 0.0.1 e00c558565f7b03a438fbd93d854b7de\n"
-      merged = GemVersionsMerge.merge(local, remote)
+      File.write(GemVersionsMerge.proxy_versions_path, remote)
+      merged = GemVersionsMerge.merge(local)
       expected = "created_at: 2021-06-27T16:14:36.466+0000\n---\n" \
                  "test-gem1 0.0.1 91643f56b430feed3f6725c91fcfac70\n" \
                  "test-gem2 0.0.1 75f21fffe3703239725b848bf82d3143\n" \
@@ -31,14 +34,43 @@ module Geminabox
     end
 
     def test_merge_multiple_remote_version_entries_are_merged
-      local = "created_at: 2021-06-27T16:14:36.466+0000\n---\ntest-gem1 0.0.1 91643f56b430feed3f6725c91fcfac70\ntest-gem2 0.0.1 75f21fffe3703239725b848bf82d3143\n"
+      local = "created_at: 2021-06-27T16:14:36.466+0000\n---\ntest-gem1 0.0.1 91643f56b430feed3f6725c91fcfac70\ntest-gem2 0.0.1 75f21fffe3703239725b848bf82d3143\ntest-gem4 0.0.1 75f21fffe3703239725b848bf82d3143\n"
       remote = "created_at: 2021-06-27T16:14:36.466+0000\n---\ntest-gem3 0.0.1,0.0.2 c379eb80dd9b53e8b99e5507c8aebcb0\ntest-gem3 1.0.0 4e58bc03e301f704950410b713c20b69\n"
-      merged = GemVersionsMerge.merge(local, remote)
+      File.write(GemVersionsMerge.proxy_versions_path, remote)
+      merged = GemVersionsMerge.merge(local)
       expected = "created_at: 2021-06-27T16:14:36.466+0000\n---\n" \
                  "test-gem1 0.0.1 91643f56b430feed3f6725c91fcfac70\n" \
                  "test-gem2 0.0.1 75f21fffe3703239725b848bf82d3143\n" \
-                 "test-gem3 0.0.1,0.0.2,1.0.0 4e58bc03e301f704950410b713c20b69\n"
+                 "test-gem3 0.0.1,0.0.2 c379eb80dd9b53e8b99e5507c8aebcb0\n" \
+                 "test-gem3 1.0.0 4e58bc03e301f704950410b713c20b69\n" \
+                 "test-gem4 0.0.1 75f21fffe3703239725b848bf82d3143\n"
       assert_equal expected, merged
+    end
+
+    def test_file_merge
+      local = "created_at: 2021-06-27T16:14:36.466+0000\n---\ntest-gem1 0.0.1 91643f56b430feed3f6725c91fcfac70\ntest-gem2 0.0.1 75f21fffe3703239725b848bf82d3143\n"
+      remote = "created_at: 2021-06-27T16:14:36.466+0000\n---\ntest-gem2 1.0.0 4e58bc03e301f704950410b713c20b69\ntest-gem3 0.0.1,0.0.2 c379eb80dd9b53e8b99e5507c8aebcb0\ntest-gem2 1.0.0 4e58bc03e301f704950410b713c20b69\ntest-gem2 1.0.0 4e58bc03e301f704950410b713c20b69\ntest-gem2 1.0.0 4e58bc03e301f704950410b713c20b69\ntest-gem2 1.0.0 4e58bc03e301f704950410b713c20b69\ntest-gem3 1.1.1 4e58bc03e301f704950410b713c20b69\n"
+      expected = <<~HEREDOC
+        created_at: 2021-06-27T16:14:36.466+0000
+        ---
+        test-gem1 0.0.1 91643f56b430feed3f6725c91fcfac70
+        test-gem2 0.0.1 75f21fffe3703239725b848bf82d3143
+        test-gem3 0.0.1,0.0.2 c379eb80dd9b53e8b99e5507c8aebcb0
+        test-gem3 1.1.1 4e58bc03e301f704950410b713c20b69
+      HEREDOC
+      StringIO.open(local) do |local_versions_file|
+        StringIO.open(remote) do |remote_versions_file|
+          remote_preamble = remote_versions_file.readline
+          local_preamble = local_versions_file.readline
+          remote_time = Time.parse(remote_preamble.split[1])
+          local_time = Time.parse(local_preamble.split[1])
+          preamble = (local_time > remote_time ? remote_preamble : local_preamble)
+          GemVersionsMerge.write_version_entries(preamble, local_versions_file, remote_versions_file)
+        end
+      end
+
+      result = File.read(GemVersionsMerge.merged_versions_path)
+      assert_equal(expected, result)
     end
 
   end


### PR DESCRIPTION
Goals:
Present a solution that's considerably more memory efficient when updating the versions list using file streams so they can be done just in time instead of using a cronjob or some other external solution, while maintaining speed.

Follow Rubygems.org's spec as an upstream as much as possible and don't overcomplicate the solution.

Background:
Rubygems.org's versions endpoint returns an ordered list of names and versions of those names served, that gets regenerated about once a week or so.   Between that time, any new uploads of a gem get appended to the end of the list with a new entry containing a single version and a version hash for that version.  There CAN be duplicates.

This solution is somewhat defensive in that any copies of a given gem in the list that we have a name for locally should not be served, this is because internally an organization may have a gem with the same name as a gem hosted on the primary source, rubygems.org, or they may have a custom version of a gem that was modified to suit their needs, and in most cases it's best to simply go with a behavior that will yield a lower chance for surprise. 

TODO:
- [ ] Update tests to follow new specs, some tests in the compact index suite are extraneous, still identifying which.
- [ ] Ensure that the changes work in a reliable fashion, some crowd sourced testing with a build based off this PR would be helpful here.
- [ ] Ensure that our code health meets the requirements set forth by the code climate configurations in the upstream repository. 